### PR TITLE
Replace charAt calls with get calls in KotlinEmitter

### DIFF
--- a/jflex/src/main/java/jflex/generator/KotlinEmitter.java
+++ b/jflex/src/main/java/jflex/generator/KotlinEmitter.java
@@ -835,7 +835,7 @@ public final class KotlinEmitter extends IEmitter {
         println("        // (if we have counted one line too much)");
         println("        var zzPeek: Boolean");
         println("        if (zzMarkedPosL < zzEndReadL)");
-        println("          zzPeek = zzBufferL.charAt(zzMarkedPosL) == '\\n'");
+        println("          zzPeek = zzBufferL[zzMarkedPosL] == '\\n'");
         println("        else if (zzAtEOF)");
         println("          zzPeek = false");
         println("        else {");
@@ -846,7 +846,7 @@ public final class KotlinEmitter extends IEmitter {
         println("          if (eof)");
         println("            zzPeek = false");
         println("          else");
-        println("            zzPeek = zzBufferL.charAt(zzMarkedPosL) == '\\n'");
+        println("            zzPeek = zzBufferL[zzMarkedPosL] == '\\n'");
         println("        }");
         println("        if (zzPeek) yyline--");
         println("      }");
@@ -858,7 +858,7 @@ public final class KotlinEmitter extends IEmitter {
       // if match was empty, last value of zzAtBOL can be used
       // zzStartRead is always >= 0
       println("      if (zzMarkedPosL > zzStartRead) {");
-      println("        when (zzBufferL.charAt(zzMarkedPosL-1)) {");
+      println("        when (zzBufferL[zzMarkedPosL-1]) {");
       println("         '\\n' -> {}");
       println("         '\\u000B' -> {}  // fall through");
       println("         '\\u000C' -> {}  // fall through");
@@ -869,7 +869,7 @@ public final class KotlinEmitter extends IEmitter {
       println("          }");
       println("         '\\r' -> {");
       println("          if (zzMarkedPosL < zzEndReadL)");
-      println("            zzAtBOL = zzBufferL.charAt(zzMarkedPosL) != '\\n'");
+      println("            zzAtBOL = zzBufferL[zzMarkedPosL] != '\\n'");
       println("          else if (zzAtEOF)");
       println("            zzAtBOL = false");
       println("          else {");
@@ -880,7 +880,7 @@ public final class KotlinEmitter extends IEmitter {
       println("            if (eof) ");
       println("              zzAtBOL = false");
       println("            else ");
-      println("              zzAtBOL = zzBufferL.charAt(zzMarkedPosL) != '\\n'");
+      println("              zzAtBOL = zzBufferL[zzMarkedPosL] != '\\n'");
       println("          }");
       println("          }");
       println("        else -> {");


### PR DESCRIPTION
Turns out that in kotlin.CharSequence interface doesn't have `charAt` method. Instead, kotlin-based generated lexers should use `get` methods to get char at a specified position. This pull request is addressing this issue.